### PR TITLE
Enabled DVC to Docker

### DIFF
--- a/trainer.dockerfile
+++ b/trainer.dockerfile
@@ -11,12 +11,21 @@ COPY requirements.txt requirements.txt
 COPY pyproject.toml pyproject.toml
 COPY project_winegrape_src_files/ project_winegrape_src_files/
 COPY data/ data/
+COPY .dvc/tmp/default.json /root/.cache/pydrive2fs/710796635688-iivsgbgsb6uv1fap6635dhvuei09o66c.apps.googleusercontent.com/default.json
 
 # Install Python dependencies
 
 WORKDIR /
 RUN pip install -r requirements.txt --no-cache-dir
 RUN pip install . --no-deps --no-cache-dir
+RUN pip install dvc
+RUN pip install "dvc[gdrive]"
+
+RUN dvc init --no-scm
+COPY .dvc/config .dvc/config
+COPY *.dvc *.dvc
+RUN dvc config core.no_scm true
+RUN dvc pull
 
 # Set the entrypoint for the container
 ENTRYPOINT ["python", "-u", "project_winegrape_src_files/train_model.py"]


### PR DESCRIPTION
dvc pull works with Oauth2 in docker training script. Find your gdrive credentials located in $CACHE_HOME/pydrive2fs/{gdrive_client_id}/default.json file, and copy it to .dvc/tmp/default.json.